### PR TITLE
Adding "bin" so tool can easily be invoked from npm run scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+readmes

--- a/get-readmes.js
+++ b/get-readmes.js
@@ -1,22 +1,17 @@
 #!/usr/bin/env node
 var fs = require('fs');
-var argv = require('minimist')(process.argv.slice(2));
+var path = require('path');
 require('./lib.js');
 
-// Defaults
-var VERBOSE = false;
-var REPOS = '.';
-var OUTPATH = './readmes';
+var defaults = {
+  repos : '.',
+  out : 'readmes'
+};
+var argv = require('minimist')(process.argv.slice(2), {default : defaults});
 
-// Process command-line options
-if (argv.repos ) {
-  REPOS = argv.repos;
-}
-REPOS = REPOS + '/repos.json';
-
-if (argv.out ) {
-  OUTPATH = argv.out;
-}
+//make paths relative to CWD unless they're absolute paths
+var REPOS = path.resolve(process.cwd(), argv.repos, 'repos.json');
+var OUTPATH = path.resolve(process.cwd(), argv.out);
 
 // Create output dir if it does not exist
 if (!fileOrDirExists(OUTPATH, true)) {

--- a/get-readmes.js
+++ b/get-readmes.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 var fs = require('fs');
 var argv = require('minimist')(process.argv.slice(2));
 require('./lib.js');

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "getreadmes",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Get README files from GitHub",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "bin" : {
-    "get-readmes" : "get-readmes.js" 
+  "bin": {
+    "get-readmes": "get-readmes.js"
   },
   "author": "C. Rand McKinney",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "getreadmes",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Get README files from GitHub",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "bin" : {
+    "get-readmes" : "get-readmes.js" 
+  },
   "author": "C. Rand McKinney",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Purpose is to ease setup/workflow for [loopback.io](https://github.com/strongloop/loopback.io).

Goal: for update readmes from loopback.io:
1. `npm i` (first time)
2. `npm run fetch-readmes`
